### PR TITLE
Remove mini_racer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,8 +142,6 @@ group :test do
   gem 'capybara-screenshot'
   gem 'webdrivers'
 
-  gem 'mini_racer'
-
   # Minitest
   gem 'minitest'
   gem "minitest-rails", "~> 5.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,8 +267,6 @@ GEM
       addressable (~> 2.7)
     lcsort (0.9.1)
     library_stdnums (1.6.0)
-    libv8 (8.4.255.0)
-    libv8 (8.4.255.0-x86_64-darwin-19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -289,8 +287,6 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
     minitest (5.14.2)
     minitest-rails (5.2.0)
       minitest (~> 5.10)
@@ -561,7 +557,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   marc (>= 0.5.0)
   marc_display!
-  mini_racer
   minitest
   minitest-rails (~> 5.2.0)
   multi_json (~> 1.4)
@@ -590,4 +585,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.2.2
+   2.2.5


### PR DESCRIPTION
This isn't needed if you have `node` installed and
the v8 dep takes a large amount of time to compile.

Just make sure to `brew install node` before running the
tests.

If this is merged I'll go and update the HOWTO to include
installing node as well. 