### PR TITLE
Gems: Add ExceptionNotification for catching and emailing application errors.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,9 @@ gem 'flipper', '~> 0.19'
 gem 'flipper-active_record'
 gem 'flipper-ui'
 
+# Capture application errors
+gem 'exception_notification', '~> 4.4.0'
+
 # Turn off those copious useless asset served lines in log in
 # development.
 #gem 'quiet_assets', :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,9 @@ GEM
     equalizer (0.0.11)
     erubi (1.10.0)
     erubis (2.7.0)
+    exception_notification (4.4.3)
+      actionmailer (>= 4.0, < 7)
+      activesupport (>= 4.0, < 7)
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
@@ -544,6 +547,7 @@ DEPENDENCIES
   debride
   debugger
   dotenv-rails
+  exception_notification (~> 4.4.0)
   faraday
   flipper (~> 0.19)
   flipper-active_record

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,5 +70,14 @@ Catalyst::Application.configure do
   config.tracker = "UA-7867593-9"
   ENV["GOOGLE_ANALYTICS"] = config.tracker
 
-
+  # Exception email notification
+  Rails.application.config.middleware.use(
+    ExceptionNotification::Rack,
+    email: {
+      email_prefix: '[Catalyst Error] ',
+      # Google Groups won't accept messages unless the sender host resolves!
+      sender_address: %("Catalyst" <catalyst@#{`hostname`.strip}>),
+      exception_recipients: %w[a.morrison@jhu.edu jon.fackrell@jhu.edu j.little@jhu.edu jwang40@jhu.edu]
+    }
+  )
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Catalyst::Application.configure do
       email_prefix: '[Catalyst Error] ',
       # Google Groups won't accept messages unless the sender host resolves!
       sender_address: %("Catalyst" <catalyst@#{`hostname`.strip}>),
-      exception_recipients: %w[a.morrison@jhu.edu jon.fackrell@jhu.edu j.little@jhu.edu jwang40@jhu.edu]
+      exception_recipients: %w[LAG-Shared@jhu.edu]
     }
   )
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,8 +52,12 @@ Catalyst::Application.configure do
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
   # config.assets.precompile += %w( search.js )
 
-  # Disable delivery errors, bad email addresses will be ignored
-  # config.action_mailer.raise_delivery_errors = false
+  # ActionMailer sendmail configuration
+  config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { :host => 'catalyst.library.jhu.edu' }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)


### PR DESCRIPTION
The [ExceptionNotification gem](https://github.com/smartinez87/exception_notification) helps capture and email error messages from any Rails application.

It's been extremely helpful for the [B1G/BTAA Geoportal project](https://github.com/BTAA-Geospatial-Data-Project/geoportal). It's particularly helpful to see any 500 errors an application produces.

However, here in Catalyst, ActionMailer appears to be missing several configuration options, so I'm not certain this will work without additional action_mailer config settings. See [BTAA config](https://github.com/BTAA-Geospatial-Data-Project/geoportal/blob/develop/config/environments/production.rb#L66-L76) for example.

UPDATE: Added sendmail default settings in second commit here.
