### PR TITLE
Tests: skip horizon tests if horizon is unavailable (#7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
   SOLR_URL: http://127.0.0.1:8985/solr/blacklight-core
   CATALYST_UMLAUT_BASE_URL: https://findit.library.jhu.edu
   RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+  HORIZON_UNAVAILABLE: true
 
 jobs:
   tests:

--- a/env-example
+++ b/env-example
@@ -32,7 +32,10 @@ MYSQL_INTERNAL_PORT=3306
 
 # Flipper auth vars
 FLIPPER_USERNAME={{ flipper_username }}
-FLIPPER_PASSWORD={{ flipper_password }} 
+FLIPPER_PASSWORD={{ flipper_password }}
+
+# Horizon Availability
+HORIZON_UNAVAILABLE=false
 
 # JHU internal DNS settings
 DNS_1=10.200.1.1

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -36,6 +36,7 @@ class CatalogControllerTest < ActionDispatch::IntegrationTest
 
   # Email - Login
   test "session - should render email action" do
+    skip "Horizon Unavailable" if horizon_unavailable?
     sign_in
     get '/catalog/bib_324680/email'
     assert_response :success

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -9,6 +9,7 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "session - should render item request page" do
+    skip "Horizon Unavailable" if horizon_unavailable?
     sign_in
     get '/catalog/bib_305929/item/349606/request'
     assert_response :success

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -9,18 +9,21 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "session - should render user page" do
+    skip "Horizon Unavailable" if horizon_unavailable?
     sign_in
     get '/user'
     assert_response :success
   end
 
   test "session - should render user requests" do
+    skip "Horizon Unavailable" if horizon_unavailable?
     sign_in
     get '/user/requests'
     assert_response :success
   end
 
   test "session - should render user profile" do
+    skip "Horizon Unavailable" if horizon_unavailable?
     sign_in
     get '/user/profile'
     assert_response :success

--- a/test/system/catalog_test.rb
+++ b/test/system/catalog_test.rb
@@ -64,6 +64,7 @@ class CatalogTest < ApplicationSystemTestCase
 
   # Scenario: Copy holdings should not show "txt" button
   def test_copy_holdings
+    skip "Horizon Unavailable" if horizon_unavailable?
     visit '/catalog/bib_305929'
     page.find('li.holding', match: :first).click # Multiple Items
     click_link('Items')
@@ -140,6 +141,7 @@ class CatalogTest < ApplicationSystemTestCase
 
   # Test Request Button - Not signed in
   def test_request_button_auth_redirect
+    skip "Horizon Unavailable" if horizon_unavailable?
     visit '/catalog/bib_305929'
     first('div.holding-visible').click
     first('a.item-children-link').click

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,4 +32,12 @@ class ActiveSupport::TestCase
       pin: Rails.application.credentials.testing[:pin]
     }
   end
+
+  def horizon_unavailable?
+    if ENV['HORIZON_UNAVAILABLE'] && ENV['HORIZON_UNAVAILABLE'] == 'true'
+      true
+    else
+      false
+    end
+  end
 end


### PR DESCRIPTION
Sets an env var ENV['HORIZON_UNAVAILABLE'] to check skipping or performing horizon dependent tests.