### PR TITLE
Exception Handling: custom 404 and 500 pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,10 @@
+# ErrorsController
+class ErrorsController < ApplicationController
+  def not_found
+    render status: 404, layout: 'blacklight', template: 'errors/not_found.html.erb'
+  end
+
+  def internal_server_error
+    render status: 500, layout: 'blacklight', template: 'errors/internal_server_error.html.erb'
+  end
+end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,10 @@
+<div class="container">
+  <div class="row">
+    <div class="col-sm-12 mt-4">
+      <h1>Internal Server Error</h1>
+      <h2 class="h5">Error code: 500</h2>
+      <p>Well... something isn't right here.</p>
+      <p>Please don't panic. We track these issues automatically and our web developers will fix the problem shortly.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,9 @@
+<div class="container">
+  <div class="row">
+    <div class="col-sm-12 mt-4">
+      <h1>Page Not Found</h1>
+      <h2 class="h5">Error code: 404</h2>
+      <p>Sorry! The page you are looking for cannot be found.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -64,11 +64,13 @@
         <%= render :partial=>'/user_util_links' %>
       </nav>
 
-      <div id="search-bar" class="search-container">
-        <div class="container">
-          <%= render :partial => "search_bar" %>
+      <% unless controller.controller_name == 'errors' %>
+        <div id="search-bar" class="search-container">
+          <div class="container">
+            <%= render :partial => "search_bar" %>
+          </div>
         </div>
-      </div>
+      <% end %>
 
       <div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
         <div class="modal-dialog">

--- a/config/application.rb
+++ b/config/application.rb
@@ -95,5 +95,8 @@ module Catalyst
 
     # temporarily suppress browse until our index is built
     #config.x.suppress_browse = true
+
+    # Exception Handling
+    config.exceptions_app = self.routes
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Catalyst::Application.routes.draw do
 
   get 'articles' => 'articles#index'
+  
+  # Error Pages for exception handling - EWL
+  match '/404' => 'errors#not_found', via: :all
+  match '/500' => 'errors#internal_server_error', via: :all
 
   if ActiveRecord::Base.connection.table_exists? 'flipper_features'
     ## Feature Flipper
@@ -166,11 +170,4 @@ Catalyst::Application.routes.draw do
 
   # will change to multi_search#index when we make multi_search default.
   root :to => "catalog#index"
-
-
-  ##
-  # Custom 404:  catch all with our own 404 to avoid 404 errors
-  # in our logs.
-  ##
-  get '*path' => "application#show404"
 end

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "bad bib id should return not_found" do
+    assert_raises(Blacklight::Exceptions::RecordNotFound) do
+      get '/catalog/bib_3437683_fail'
+    end
+  end
+
+  test "should get not_found" do
+    get '/404'
+    assert_response :success
+  end
+
+  test "should get internal_server_error" do
+    get '/500'
+    assert_response :success
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -30,8 +30,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "new" do
-    get '/user/new'
-    assert_response 404
+    assert_raises ActionController::RoutingError do
+      get '/user/new'
+    end
   end
 
   test "create" do


### PR DESCRIPTION
Removes old JHU exception handling code from application_controller. Moves exception handling to routing and errors_controller with corresponding, customizable views.