### PR TITLE
LAG-3943 Changing sort options after advanced search

### DIFF
--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,0 +1,13 @@
+<% if show_sort_and_per_page? and active_sort_fields.many? %>
+  <div id="sort-dropdown" class="sort-dropdown btn-group">
+    <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <%= t('blacklight.search.sort.label_html', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
+    </button>
+
+    <div class="dropdown-menu" role="menu">
+      <%- active_sort_fields.each do |sort_key, field_config| %>
+        <%= link_to(sort_field_label(sort_key), url_for(params.merge(sort: sort_key).reject{|_, p| p.blank?}), class: 'dropdown-item', role: 'menuitem') %>
+      <%- end -%>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
This replaces the default view for the sort dropdown with
an override that doesn't use the default Blacklight sanitize
methods which are clobbering the params for sorting after
advanced search. This does filter out params that are blank.