### PR TITLE
Emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: '"Johns Hopkins Libraries" <ask@jhu.libanswers.com>'
+  default from: '"Johns Hopkins Libraries" <catalog@jhu.edu>'
   layout 'mailer'
 end
 

--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -9,7 +9,7 @@
           <%= t('blacklight.email.form.to') %>
         </label>
         <div class="col-sm-10">
-          <%= email_field_tag :to, params[:to], class: 'form-control' %>
+          <%= email_field_tag :to, params[:to], class: 'form-control', value: current_user.email %>
         </div>
       </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -91,7 +91,7 @@ module Catalyst
 
     # email from address used for emails and email-to-SMS of bibs sent out
     # of catalyst.
-    ActionMailer::Base.default :from => '"Johns Hopkins Libraries" <ask@jhu.libanswers.com>'
+    ActionMailer::Base.default :from => '"Johns Hopkins Libraries" <catalog@jhu.edu>'
 
     # temporarily suppress browse until our index is built
     #config.x.suppress_browse = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,6 +84,7 @@ Catalyst::Application.configure do
       # Google Groups won't accept messages unless the sender host resolves!
       sender_address: %("Catalyst" <catalyst@#{`hostname`.strip}>),
       exception_recipients: %w[LAG-Shared@jhu.edu]
-    }
+    },
+    error_grouping: true
   )
 end


### PR DESCRIPTION
Includes 3 small updates related to emails. 

- Default from email was changed to catalog@jhu.edu. I tested sending to my Gmail account and it was received within a minute
- Grouped error messages so they should only be sent when the count for a particular error is 1, 2, 4, 8, 16, 32, 64, 128, ..., (2**n)
- In looking at the email form, it already requires patrons to login. It looks like we storing their JHU email so Catalyst will now pre-populate the form with the saved email to simplify the user experience