### PR TITLE
Add a GitHub Actions workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+# GitHub Actions for the release event
+
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo "${{ github.event.release.tag_name }}"
+        echo "${{ github.event.release.name }}"
+        echo "${{ github.event.release.body }}"
+    - name: Notify release to Slack
+      uses: lizefield/notify-release-to-slack@v1.0
+      with:
+        slackWebhookUrl: ${{ secrets.SLACK_WEBHOOK_URL }}
+        releaseMessage: ${{ github.event.release.body }}


### PR DESCRIPTION
This sets up a workflow that is triggered when a release is published. Right now it only notifies 
a slack channel. 