### PR TITLE
Added check to ensure existence of #hathi-etas element before comparison

### DIFF
--- a/app/javascript/umlaut_include.js
+++ b/app/javascript/umlaut_include.js
@@ -58,7 +58,7 @@ Blacklight.onLoad(function(){
       }
     }
 
-    if ($("#hathi-etas").attr("hathi-present").trim() == "true"){
+    if ($("#hathi-etas").length > 0 && $("#hathi-etas").attr("hathi-present").trim() == "true"){
       $('p.umlaut-unavailable').hide();
     }
   }


### PR DESCRIPTION
The test are currently failing unrelated to this change, but rather due to Umlaut timeouts.