### PR TITLE
Added ActionMailer configuration settings the development environme…

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,6 +22,17 @@ Catalyst::Application.configure do
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = { :host => 'catalyst.library.jhu.edu' }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :user_name => ENV['SMTP_USER_NAME'],
+    :password => ENV['SMTP_PASSWORD'],
+    :address => ENV['SMTP_ADDRESS'],
+    :domain => ENV['SMTP_DOMAIN'],
+    :port => ENV['SMTP_PORT'],
+    :authentication => :plain
+  }
 
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log


### PR DESCRIPTION
…nt config. This will allow for easier testing of email and sms sending. There are a variety of local and online tools that can be used to capture sent emails so they don't actually get sent to a person's email inbox. You will have to add the necessary variables to your .env.development in order to complete the configuration.

SMTP_USER_NAME=Development
SMTP_PASSWORD=
SMTP_ADDRESS=127.0.0.1
SMTP_DOMAIN=127.0.0.1
SMTP_PORT=2526