### PR TITLE
LAG-4045 Update for CVE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,11 @@ ruby '2.6.6'
 # we will no longer need this gem once we migrate to ansible
 gem 'dotenv-rails'
 
-gem 'rails', '~> 5.1'
+gem 'rails', '~> 5.2'
+
+# See https://github.com/advisories/GHSA-8hc4-xxm3-5ppp
+gem "activerecord", ">= 5.2.4.5"
+
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,30 +10,27 @@ GIT
 
 GIT
   remote: https://github.com/rubygarage/inquisition.git
-  revision: 0a8fdd71a56ce4360b0554c1623774b82b0159b9
+  revision: 63e1279ef3a5c3ba3db53040ac70142d8e81cf66
   specs:
     inquisition (0.2.0)
-      awesome_print
-      benchmark-ips
-      brakeman
-      bullet
-      bundler-audit
-      colorize
-      fasterer
-      hirb
-      overcommit
-      pry-byebug
-      pry-rails
-      pry-rescue
-      pry-stack_explorer
-      railroady
-      rails-erd
-      rails_best_practices
-      reek
-      rubocop
-      rubycritic
-      simplecov
-      traceroute
+      active_record_doctor (~> 1.6.0)
+      brakeman (~> 4.6)
+      bundler-audit (~> 0.6)
+      bundler-leak (~> 0.1)
+      caxlsx
+      factory_bot (~> 5.0)
+      fasterer (~> 0.6)
+      i18n-tasks (~> 0.9)
+      lol_dba (~> 2.1)
+      rails_best_practices (~> 1.19)
+      rubocop (~> 0.74)
+      rubocop-minitest (~> 0.2.1)
+      rubocop-performance (~> 1.4)
+      rubocop-rails (~> 2.3)
+      rubocop-rake (~> 0.3.0)
+      rubocop-rspec (~> 1.35)
+      rubycritic (~> 4.1)
+      traceroute (~> 0.8)
 
 PATH
   remote: marc_display
@@ -43,43 +40,46 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (5.2.4.4)
-      actionpack (= 5.2.4.4)
+    actioncable (5.2.4.5)
+      actionpack (= 5.2.4.5)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailer (5.2.4.4)
-      actionpack (= 5.2.4.4)
-      actionview (= 5.2.4.4)
-      activejob (= 5.2.4.4)
+    actionmailer (5.2.4.5)
+      actionpack (= 5.2.4.5)
+      actionview (= 5.2.4.5)
+      activejob (= 5.2.4.5)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (5.2.4.4)
-      actionview (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    actionpack (5.2.4.5)
+      actionview (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.4.4)
-      activesupport (= 5.2.4.4)
+    actionview (5.2.4.5)
+      activesupport (= 5.2.4.5)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activejob (5.2.4.4)
-      activesupport (= 5.2.4.4)
+    active_record_doctor (1.6.0)
+      activerecord (>= 4.2)
+      railties (>= 4.2)
+    activejob (5.2.4.5)
+      activesupport (= 5.2.4.5)
       globalid (>= 0.3.6)
-    activemodel (5.2.4.4)
-      activesupport (= 5.2.4.4)
-    activerecord (5.2.4.4)
-      activemodel (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    activemodel (5.2.4.5)
+      activesupport (= 5.2.4.5)
+    activerecord (5.2.4.5)
+      activemodel (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       arel (>= 9.0)
-    activestorage (5.2.4.4)
-      actionpack (= 5.2.4.4)
-      activerecord (= 5.2.4.4)
+    activestorage (5.2.4.5)
+      actionpack (= 5.2.4.5)
+      activerecord (= 5.2.4.5)
       marcel (~> 0.3.1)
-    activesupport (5.2.4.4)
+    activesupport (5.2.4.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -92,16 +92,12 @@ GEM
     ast (2.4.1)
     autoprefixer-rails (10.0.0.2)
       execjs
-    awesome_print (1.8.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt_pbkdf (1.1.0)
-    benchmark-ips (2.8.2)
     bindex (0.8.1)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     blacklight (7.11.1)
       deprecation
       globalid
@@ -129,10 +125,10 @@ GEM
       httpclient (~> 2.4)
     brakeman (4.8.2)
     builder (3.2.4)
-    bullet (6.1.0)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.11)
     bundler-audit (0.7.0.1)
+      bundler (>= 1.2.0, < 3)
+      thor (>= 0.18, < 2)
+    bundler-leak (0.2.0)
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
     byebug (11.1.3)
@@ -168,11 +164,14 @@ GEM
     capybara-screenshot (1.0.24)
       capybara (>= 1.0, < 4)
       launchy
+    caxlsx (3.0.4)
+      htmlentities (~> 4.3, >= 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
     childprocess (3.0.0)
-    choice (0.2.0)
     code_analyzer (0.5.2)
       sexp_processor
-    coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
@@ -185,7 +184,6 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.6)
       sexp_processor (~> 4.5)
-    debug_inspector (0.0.3)
     debugger (1.6.8)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
@@ -212,6 +210,8 @@ GEM
       actionmailer (>= 4.0, < 7)
       activesupport (>= 4.0, < 7)
     execjs (2.7.0)
+    factory_bot (5.2.0)
+      activesupport (>= 4.2.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     fasterer (0.8.3)
@@ -242,7 +242,8 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (3.6.0)
-    hirb (0.7.3)
+    highline (2.0.3)
+    htmlentities (4.3.4)
     http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -256,9 +257,17 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (0.9.33)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
-    iniparse (1.5.0)
-    interception (0.5)
     ipaddr_range_set (1.0.0)
     jbuilder (2.11.0)
       activesupport (>= 5.0.0)
@@ -288,6 +297,10 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lol_dba (2.2.0)
+      actionpack (>= 3.0, < 7.0)
+      activerecord (>= 3.0, < 7.0)
+      railties (>= 3.0, < 7.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -323,29 +336,12 @@ GEM
     openurl (1.0.0)
       marc
       scrub_rb (~> 1.0)
-    overcommit (0.55.0)
-      childprocess (>= 0.6.3, < 5)
-      iniparse (~> 1.4)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
     parslet (2.0.0)
     path_expander (1.1.0)
     popper_js (1.16.0)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
-    pry-rescue (1.5.2)
-      interception (>= 0.5)
-      pry (>= 0.12.0)
-    pry-stack_explorer (0.5.1)
-      binding_of_caller (~> 0.7)
-      pry (~> 0.13)
     psych (3.1.0)
     public_suffix (4.0.5)
     puma (4.3.5)
@@ -361,30 +357,27 @@ GEM
     rack_session_access (0.2.0)
       builder (>= 2.0.0)
       rack (>= 1.0.0)
-    railroady (1.5.3)
-    rails (5.2.4.4)
-      actioncable (= 5.2.4.4)
-      actionmailer (= 5.2.4.4)
-      actionpack (= 5.2.4.4)
-      actionview (= 5.2.4.4)
-      activejob (= 5.2.4.4)
-      activemodel (= 5.2.4.4)
-      activerecord (= 5.2.4.4)
-      activestorage (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    rails (5.2.4.5)
+      actioncable (= 5.2.4.5)
+      actionmailer (= 5.2.4.5)
+      actionpack (= 5.2.4.5)
+      actionview (= 5.2.4.5)
+      activejob (= 5.2.4.5)
+      activemodel (= 5.2.4.5)
+      activerecord (= 5.2.4.5)
+      activestorage (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       bundler (>= 1.3.0)
-      railties (= 5.2.4.4)
+      railties (= 5.2.4.5)
       sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     rails-perftest (0.0.7)
     rails_best_practices (1.20.0)
       activesupport
@@ -396,9 +389,9 @@ GEM
       ruby-progressbar
     rails_stats (1.0.1)
       rake
-    railties (5.2.4.4)
-      actionpack (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    railties (5.2.4.5)
+      actionpack (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
@@ -431,12 +424,18 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.2.0)
       parser (>= 2.7.0.1)
+    rubocop-minitest (0.2.1)
+      rubocop (>= 0.74)
+    rubocop-performance (1.8.0)
+      rubocop (>= 0.87.0)
     rubocop-rails (2.7.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
-    ruby-graphviz (1.2.5)
-      rexml
+    rubocop-rake (0.3.1)
+      rubocop
+    rubocop-rspec (1.43.2)
+      rubocop (~> 0.87)
     ruby-prof (1.4.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
@@ -505,6 +504,8 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    terminal-table (3.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -531,7 +532,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    uniform_notifier (1.13.0)
     view_component (2.24.0)
       activesupport (>= 5.0.0, < 7.0)
     virtus (1.0.5)
@@ -565,6 +565,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  activerecord (>= 5.2.4.5)
   bcrypt_pbkdf
   blacklight (= 7.11.1)
   blacklight-marc (= 7.0)
@@ -609,7 +610,7 @@ DEPENDENCIES
   openurl (>= 0.1.0)
   puma (~> 4.1)
   rack_session_access
-  rails (~> 5.1)
+  rails (~> 5.2)
   rails-perftest
   rails_stackview!
   rails_stats


### PR DESCRIPTION
This updates our Rails installation to Rails 5.2.4.5 to bring
in a patch for this CVE: https://github.com/advisories/GHSA-8hc4-xxm3-5ppp

The CVE only applies to installs that use postgresql so it does
not apply to this app.