### PR TITLE
LAG-4048 Always use simple url for advanced search

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,27 @@
+module SearchHelper
+  include ActionView::Helpers::UrlHelper
+
+  def advanced_search_markup(url:)
+    link_to 'Advanced Search', url, class: 'advanced_search'
+  end
+
+  def advanced_search_link(params:)
+    case
+    when advanced_search?
+      advanced_search_markup(url: params.merge(controller: 'advanced', action: 'index'))
+    when quick_search?
+      params[:all_fields] = params[:q]
+      advanced_search_markup(url: params.merge(controller: 'advanced', action: 'index'))
+    else
+      advanced_search_markup(url: '/advanced')
+    end
+  end
+
+  def advanced_search?
+    params.try(:[], :search_field) == 'advanced'
+  end
+
+  def quick_search?
+    params.try(:[], :q).present?
+  end
+end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -116,7 +116,7 @@
             <%= label_tag(:online_only, "Show only items available online", :id => "online_only_label") %>
           </div>
           <div class="link-more-search-options col-12 col-md-6 text-right">
-            <%= link_to 'Advanced Search', params.merge(:controller=>"advanced", :action=>"index"), :class=>"advanced_search" %>
+            <%= advanced_search_link(params: params) %>
           </div>
         </div>
       </div>

--- a/test/system/advanced_search_link_test.rb
+++ b/test/system/advanced_search_link_test.rb
@@ -1,0 +1,30 @@
+# coding: utf-8
+require "application_system_test_case"
+
+class AdvancedSearchLinkTest < ApplicationSystemTestCase
+  def test_advanced_search_link_from_bib_show
+    visit '/catalog/bib_4839582'
+    click_on 'Advanced Search'
+
+    assert_equal page.current_path, '/advanced'
+    refute_match /search_field/, page.current_url
+  end
+
+  def test_advanced_search_link_from_advanced_search
+    visit '/advanced'
+    fill_in 'Any Field', with: 'testing-the-search'
+    click_on 'Search'
+    click_on 'Advanced Search'
+
+    assert page.has_xpath?("//input[@value='testing-the-search']")
+  end
+
+  def test_advanced_search_link_from_search
+    visit '/'
+    fill_in 'Q', with: 'testing-the-search'
+    click_on 'Search'
+    click_on 'Advanced Search'
+
+    assert page.has_xpath?("//input[@value='testing-the-search']")
+  end
+end


### PR DESCRIPTION
This changes the URL to advanced search so that it doesn't
include the current params. Without this the data in Google Analytics
contains those params and makes analysis harder.