### PR TITLE
LAG-3997 Turn off saved searches for bots

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -100,6 +100,10 @@ class CatalogController < ApplicationController
   before_action :spellcheck, :only => :index
 
   configure_blacklight do |config|
+
+    # Do not store searches for bots
+    config.crawler_detector = ->(req) { req.env['HTTP_USER_AGENT'] =~ /bot/ }
+
     # default components
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 


### PR DESCRIPTION
Blacklight has a config called `crawler_detector` that
can be used to turn off saved searches and based on the
user agent.

This sets the detector to look for `bot` in the user agent.