### PR TITLE
LAG-4068 LAG-4069 Advanced search/quick search behavior

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,16 +1,29 @@
 module SearchHelper
   include ActionView::Helpers::UrlHelper
 
+  ##
+  # Return a label for the currently selected search field.
+  # This overrides the default blacklight helper, which
+  # removes the label if it is the default search field.
+  #
+  # See LAG-4069 for the reasoning behind this change.
+  # Overrides:
+  # https://github.com/projectblacklight/blacklight/blob/bb769cdd4f1b7373a0797c731ae2949bf051e86f/app/helpers/blacklight/configuration_helper_behavior.rb#L53
+  def constraint_query_label(localized_params = params)
+    if !label_for_search_field(localized_params[:search_field]).present?
+      'Any Field' # Force a label for the default search field
+    else
+      label_for_search_field(localized_params[:search_field])
+    end
+  end
+
   def advanced_search_markup(url:)
     link_to 'Advanced Search', url, class: 'advanced_search'
   end
 
   def advanced_search_link(params:)
     case
-    when advanced_search?
-      advanced_search_markup(url: params.merge(controller: 'advanced', action: 'index'))
-    when quick_search?
-      params[:all_fields] = params[:q]
+    when advanced_search? || quick_search?
       advanced_search_markup(url: params.merge(controller: 'advanced', action: 'index'))
     else
       advanced_search_markup(url: '/advanced')

--- a/test/system/advanced_search_link_test.rb
+++ b/test/system/advanced_search_link_test.rb
@@ -27,4 +27,11 @@ class AdvancedSearchLinkTest < ApplicationSystemTestCase
 
     assert page.has_xpath?("//input[@value='testing-the-search']")
   end
+
+  def test_advanced_title_search_link_from_search
+    visit '/catalog?utf8=✓&search_field=title&q=test'
+    click_on 'Advanced Search'
+
+    refute page.has_field? 'Any Field', with: 'testing-the-search'
+  end
 end

--- a/test/system/catalog_test.rb
+++ b/test/system/catalog_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require "application_system_test_case"
 
 class CatalogTest < ApplicationSystemTestCase

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -1,0 +1,11 @@
+# coding: utf-8
+require "application_system_test_case"
+
+class SearchTest < ApplicationSystemTestCase
+  def test_having_a_label_for_any_field_search
+    visit '/'
+    fill_in 'Q', with: 'test'
+    click_on 'Search'
+    assert page.has_content?('Any Field')
+  end
+end


### PR DESCRIPTION
This simplifies the creation of the advanced search link
based on changes from LAG-4050. This avoids a 
search term always being in the `Any Field` field
in advanced search even if you selected title from 
the dropdown. 

This overrides the default blacklight label behavior
so that we show the Any Field label on results pages
for the quick search/default search.