### PR TITLE
Remove ActionController::RoutingError exceptions thrown by missing reserves 

### DIFF
--- a/app/controllers/reserves_controller.rb
+++ b/app/controllers/reserves_controller.rb
@@ -7,6 +7,8 @@ class ReservesController < CatalogController
   # Avoid BL7 /track method on link_to_document
   self.blacklight_config.track_search_session = false
 
+  rescue_from ActiveRecord::RecordNotFound, :with => -> { render status: 404, layout: 'blacklight', template: 'errors/not_found.html.erb' }
+
   def initialize
     super
 
@@ -53,11 +55,8 @@ class ReservesController < CatalogController
   end
 
   def show
-    begin
-      @course = ReservesCourse.includes(:bib_ids).find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      raise ActionController::RoutingError.new('Not Found')
-    end
+
+    @course = ReservesCourse.includes(:bib_ids).find(params[:id])
 
     @bib_ids                  =  @course.bib_ids
     solr_ids                  = @bib_ids.collect {|j| "bib_" + j.bib_id.to_s}


### PR DESCRIPTION
Removed existing rescue which throws a routing exception which is currently being sent to bug trackers.

This change will catch the ActiveRecord::RecordNotFound exception on the Reserves Controller and respond with a 404 status and render the appropriate template.