### PR TITLE
LAG-3997 Catalyst stored searches

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -36,6 +36,8 @@ require "capistrano/bundler"
 require "capistrano/passenger"
 require "capistrano/locally"
 require "capistrano/rails"
+require "whenever/capistrano"
+
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,9 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'appsignal'
 
+# For cron jobs
+gem 'whenever', require: false
+
 
 # Turn off those copious useless asset served lines in log in
 # development.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 1.3.0, < 3)
     childprocess (3.0.0)
+    chronic (0.10.2)
     code_analyzer (0.5.2)
       sexp_processor
     coercible (1.0.0)
@@ -567,6 +568,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
@@ -644,6 +647,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 5.x)
+  whenever
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -56,6 +56,12 @@ before "deploy:assets:precompile", "deploy:yarn_install"
 set :bundle_roles, :all
 set :bundle_path, -> { shared_path.join('bundle') }
 
+## Whenever options
+set :whenever_environment, 'production'
+set :whenever_roles, :web
+set :whenever_identifier, ->{ "#{fetch(:application)}" }
+
+
 namespace :deploy do
   task :group_permissions do
     on roles(:app, :web) do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,15 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+
+every :day, at: '2:00am' do
+   rake 'nightly_cleanup'
+end
+
+# Learn more: http://github.com/javan/whenever

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -2,45 +2,22 @@
 # in cronfile (by capistrano with whenever), chain any tasks
 # you need done nightly off of here in more rake pre-reqs like so...
 
-desc "Nightly db cleanup tasks for JH Catalyst"
-task "nightly_cleanup" => [:purge_searches, :purge_guest_users]
+desc 'Nightly db cleanup tasks for JH Catalyst'
+task 'nightly_cleanup' => [:purge_searches]
 
 
-desc "purge old search data"
-task "purge_searches" => :environment do
-  # BL comes with a task to delete old records from Searches table,
-  # but it's a hot mess, using destroy_all instead of delete_all
-  # (horrible idea on lots of rows), 7 days (too long), etc. 
-  # we just redo it ourselves, sorry.
-  puts "#{DateTime.now}: Purging searches more than 2 days old"    
-  searches = Search.delete_all(['created_at < ? AND user_id IS NULL', DateTime.now - 2.days])  
-  puts "   Purged #{searches} searches"
-end
+desc 'purge old search data'
+task 'purge_searches' => :environment do
+  # We don't use saved searches anymore, but it is used
+  # when paging through results on a show page
 
-# For bookmarks with un-logged in users, BL wants us to create
-# temporary guest users. We need to purge them, as well as any
-# related data. 
-desc "Purge old guest user data"
-task "purge_guest_users" => :environment do
-  days_old    = (ENV["GUEST_DAYS_OLD"] || 7).to_i.days
-  older_than  = DateTime.now - days_old
-  puts "#{DateTime.now}: Purging guest user data older than #{days_old.inspect} ago"
-
-  # We're going to create the Arel for old guest users, then use
-  # it to hand-construct DELETE's for bookmarks and searches
-  # corresponding to those users using a sub-query. Before
-  # deleting the users themselves too. 
-  #
-  # If we were in Rails4, we could do more natural deletes
-  # with joins. 
-  # http://stackoverflow.com/questions/4235838/rails-is-it-possible-to-delete-all-with-inner-join-conditions
-  # https://github.com/rails/rails/issues/919  
-  expired_guests = User.where(:guest => true).where(["created_at < ?", older_than])
-  inner_query    = expired_guests.select("users.id")
-
-  bookmarks = Bookmark.where(:user_id => inner_query).delete_all
-  searches  = Search.where(:user_id => inner_query).delete_all
-  users     = expired_guests.delete_all
-
-  puts "   Purged #{bookmarks} bookmarks, #{searches} searches, and #{users} guest users."
+  # This is the most efficient way to delete all the searches
+  begin
+    ActiveRecord::Base.connection.execute('TRUNCATE searches')
+    puts 'The searches table has been truncated.'
+  rescue ActiveRecord::ConnectionNotEstablished
+    puts 'There was a problem connecting to the database.'
+  rescue StandardError
+    puts 'An error occurred when truncating the searches table.'
+  end
 end


### PR DESCRIPTION
This adds a nightly task using `whenever` to
clear out saved searches.The cron tab
entries are installed on the server when the
application is deployed with `capistrano`.

It looks like tasks and the capistrano/whenever
setup existed before, but weren't migrated when
the move to `ansible` happened.

I removed the existing tasks for cleaning out searches
and users. As we accumulate users we will need to
reinstate a similar task, but we will need to be careful
because we won't be able to use `TRUNCATE` like we are
with searches.