### PR TITLE
Update blacklight_cql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'borrow_direct', ">= 1.2.0.pre1", "< 2.0"  # for generating queries to BD
 # gem "chosen_assets" #, :path => "../chosen-rails" # used to add fancy combo box UI to advanced search form facets
 #gem 'chosen-rails' #  jquery multiselect plugin for advanced search
 
-# gem "blacklight_cql", "~> 3.0"
+gem "blacklight_cql", git: 'https://github.com/jhu-library-applications/blacklight_cql.git', branch: 'bl-upgrade'
 
 # Removing Bento / EWL
 # gem "bento_search", "~> 1.6" #, :github => "jrochkind/bento_search", :branch => "master"  # for multi-search support, article search, google site, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/jhu-library-applications/blacklight_cql.git
+  revision: 150804b99543f62496a188ed34d35eeac4a1126c
+  branch: bl-upgrade
+  specs:
+    blacklight_cql (3.0.1)
+      blacklight (>= 5.14.0)
+      cql-ruby (>= 0.8.1)
+      rails
+
+GIT
   remote: https://github.com/jhu-sheridan-libraries/rails_stackview
   revision: 62a113f4cfcb61b124297e5c2d8ec02d0e3de935
   branch: blacklight-7.0
@@ -275,7 +285,7 @@ GEM
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
     ipaddr_range_set (1.0.0)
-    jbuilder (2.11.0)
+    jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -548,7 +558,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    view_component (2.24.0)
+    view_component (2.30.0)
       activesupport (>= 5.0.0, < 7.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -593,6 +603,7 @@ DEPENDENCIES
   blacklight (= 7.11.1)
   blacklight-marc (= 7.0)
   blacklight_advanced_search (~> 7.0)
+  blacklight_cql!
   blacklight_range_limit (~> 7.0)
   bootstrap (~> 4.0)
   borrow_direct (>= 1.2.0.pre1, < 2.0)
@@ -662,4 +673,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.6
+   2.2.16

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -18,6 +18,10 @@ class CatalogController < ApplicationController
   # Recreating locally to ensure layout choice is correct
   layout :determine_layout
 
+  # Required by Find It / Umlaut
+  include BlacklightCql::ControllerExtension
+
+
   # @TODO: Strong params everywhere
   ActionController::Parameters.permit_all_parameters = true
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,6 +2,9 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
 
+  # Required by Find It / umlaut
+  include BlacklightCql::SearchBuilderExtension
+
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
   self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
 


### PR DESCRIPTION
This gem needed to be updated to work with BL7.

The gem is used by Find It to look up holdings information
from Catalyst.

Find It makes requests that look like this:

https://catalyst.library.jhu.edu/catalog.atom?search_field=cql&content_format=marc&q=title+%3D+%22%5C%22Test+Conference%2C+IEEE+International%5C%22%22&f[format][]=Journal%2FNewspaper/