### PR TITLE
Remove AppSignal JS

### DIFF
--- a/app/javascript/packs/application.js.erb
+++ b/app/javascript/packs/application.js.erb
@@ -35,14 +35,3 @@ import '../umlaut_include'
 import { has_rmst_cookie, toggle_rmst_cookie } from '../rmst'
 global.has_rmst_cookie = has_rmst_cookie
 global.toggle_rmst_cookie = toggle_rmst_cookie
-
-
-// AppSignal
-import Appsignal from '@appsignal/javascript' // For ES Module
-import { plugin } from '@appsignal/plugin-window-events'
-
-const appsignal = new Appsignal({
-  key: "<%= ENV['APPSIGNAL_FRONTEND_KEY'] %>",
-})
-
-appsignal.use(plugin)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
   "dependencies": {
-    "@appsignal/javascript": "^1.3.12",
-    "@appsignal/plugin-window-events": "^1.0.6",
     "@rails/ujs": "^6.1.1",
     "@rails/webpacker": "5.2.1",
     "@sentry/browser": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,36 +2,6 @@
 # yarn lockfile v1
 
 
-"@appsignal/core@^1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@appsignal/core/-/core-1.1.7.tgz#522b4124e6dd8715bfcf1a2dbba0d07f2128219c"
-  integrity sha512-xyjJIg0x8u0+EQhFGnK9IzG4vY97D/YLM1NFgRX0lUg+bYuWHEemblWbU3/2JDNKqHhpJW5/8yjVqGR9P64lVQ==
-  dependencies:
-    "@appsignal/types" "^2.0.5"
-    isomorphic-unfetch "^3.1.0"
-    tslib "^2.0.3"
-
-"@appsignal/javascript@^1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@appsignal/javascript/-/javascript-1.3.12.tgz#89f946c197e21472837fbd94a308793874e0a009"
-  integrity sha512-uinylUwbBsjd6sIc3EQsOSoRCVYp7ue62B//tTnGxu71+yig1TGRfGbWtNSuWHWMqz2zZ7GzTXnmayUeeyWR9A==
-  dependencies:
-    "@appsignal/core" "^1.1.7"
-    "@appsignal/types" "^2.0.5"
-    tslib "^2.0.3"
-
-"@appsignal/plugin-window-events@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@appsignal/plugin-window-events/-/plugin-window-events-1.0.6.tgz#c461ad9ecf93e3cf737c66465150941f1f0e4e3c"
-  integrity sha512-QJBia+oldhl14eTdJwC+XFBfF3bO6ljFf53tNiMkLVP4AoXA0uP+E0MZhenC4Wxm7kCCbSXUutKUhqfoFJfj+g==
-  dependencies:
-    "@appsignal/types" "^2.0.5"
-
-"@appsignal/types@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@appsignal/types/-/types-2.0.5.tgz#a7de841b21b3fa5668da1f7ef523ea851e5eb0e6"
-  integrity sha512-T2Fi6co9Yft4KY1Ij/RcPV+BUTU8jSgtWXeFanPn5qPaZwRj8kh7jO/3B1inMlP11FYWWkO7Ugz5+HbetSvJ0A==
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -4135,14 +4105,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-unfetch@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
-  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
-  dependencies:
-    node-fetch "^2.6.1"
-    unfetch "^4.2.0"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -4762,11 +4724,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -7331,11 +7288,6 @@ tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
-
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -7372,11 +7324,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-unfetch@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
-  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This removes AppSignal JS. We are relying
on Sentry.io for capturing front-end errors.