### PR TITLE
LAG-4185 Redirect CQL queries from Find It

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,6 +14,8 @@ require 'search_builder'
 require 'dlf_expanded_passthrough/document_extension'
 
 class CatalogController < ApplicationController
+  include CqlHelper
+
   # @TODO: BL should do this, but it is not working here
   # Recreating locally to ensure layout choice is correct
   layout :determine_layout
@@ -21,6 +23,13 @@ class CatalogController < ApplicationController
   # Required by Find It / Umlaut
   include BlacklightCql::ControllerExtension
 
+  def index
+    super
+
+    if params[:content_format] == 'marc' && params[:search_field] == 'cql' && params[:format] == 'html'
+      redirect_to search_catalog_url reformatted_cql_search(params: params)
+    end
+  end
 
   # @TODO: Strong params everywhere
   ActionController::Parameters.permit_all_parameters = true

--- a/app/helpers/cql_helper.rb
+++ b/app/helpers/cql_helper.rb
@@ -1,0 +1,21 @@
+# Helpers for dealing with CQL queries
+module CqlHelper
+  def reformatted_cql_search(params:)
+    return unless params[:q].present? && params[:f].present?
+
+    query = params[:q]
+    facets = params[:f]
+
+    reformatted_q = case query
+                    when /title = "\\"(.*)\\"" author = "\\"(.*)\\"\"/
+                      captures = query.match(/title = "\\"(.*)\\\"\" author = "\\"(.*)\\\"\"/).captures
+
+                      { q: "#{captures[0]} #{captures[1]}" , search_field: 'all_fields', f: facets }
+                    when /title = "\\"(.*)\\"\"/
+                      { q: query.match(/title = "\\"(.*)\\"\"/).captures[0], search_field: 'title', f: facets }
+                    when /\Aauthor = "\\"(.*)\\"\"/
+                      { q: query.match(/author = "\\"(.*)\\"\"/).captures[0], search_field: 'author', f: facets }
+                    end
+    reformatted_q
+  end
+end

--- a/test/helpers/cql_helper_test.rb
+++ b/test/helpers/cql_helper_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class CqlHelperTest < ActionView::TestCase
+  test 'that we can remove CQL formatting from a title CQL query' do
+    actual_params = { content_format: 'marc', q: 'title = "\"Accounts of Chemical Research\""', search_field: 'cql', f: '[format][]=Journal/Newspaper' }
+    ideal_params = { search_field: 'title', q: 'Accounts of Chemical Research', f: '[format][]=Journal/Newspaper' }
+
+    assert_equal ideal_params, reformatted_cql_search(params: actual_params)
+  end
+
+  test 'that we can remove CQL formatting from an author CQL query' do
+    actual_params = { content_format: 'marc', q: 'author = "\"J Smith\""', search_field: 'cql', f: '[format][]=Journal/Newspaper' }
+    ideal_params = { search_field: 'author', q: 'J Smith', f: '[format][]=Journal/Newspaper' }
+
+    assert_equal ideal_params, reformatted_cql_search(params: actual_params)
+  end
+
+  test 'that we can remove CQL formatting from a title & author CQL query' do
+    actual_params = { content_format: 'marc', q: 'title = "\"Accounts of Chemical Research\"" author = "\"J Smith\""', search_field: 'cql', f: '[format][]=Journal/Newspaper' }
+    ideal_params = {  q: 'Accounts of Chemical Research J Smith', search_field: 'all_fields', f: '[format][]=Journal/Newspaper' }
+
+    assert_equal ideal_params, reformatted_cql_search(params: actual_params)
+  end
+end

--- a/test/system/cql_test.rb
+++ b/test/system/cql_test.rb
@@ -16,4 +16,18 @@ class CqlTest < ApplicationSystemTestCase
 
     assert page.has_content? '/catalog/bib_2653739</id>'
   end
+
+  def test_that_cql_queries_from_find_it_are_redirected
+    holdings_stub
+
+    visit '/catalog.html?content_format=marc&f%5Bformat%5D%5B%5D=Journal%2FNewspaper&q=title+%3D+"%5C"Accounts+of+Chemical+Research%5C""&search_field=cql'
+    page.have_css?(".filter-name", text: "Title")
+  end
+
+  def test_that_cql_queries_from_find_it_are_redirected
+    holdings_stub
+
+    visit '/catalog.html?content_format=marc&f%5Bformat%5D%5B%5D=Journal%2FNewspaper&q=author+%3D+"%5C"J+Smith%5C""&search_field=cql'
+    page.has_css?('.filter-name', text: 'Author')
+  end
 end


### PR DESCRIPTION
Find It makes links to Catalyst that look like this:

```
/catalog.html?content_format=marc&f%5Bformat%5D%5B%5D=Journal%2FNewspaper&q=title+%3D+"%5C"Accounts+of+Chemical+Research%5C""&search_field=cql
```

This PR redirects those URLs to this path:

```
/catalog?q=Accounts+of+Chemical+Research&search_field=all_fields
```

This will keep the user from being in a state where they are searching with CQL.