### PR TITLE
LAG-4268 Added Blacklight unAPI gem to replace COinS data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'marc_display', :path => "./marc_display"
 
 gem "blacklight_range_limit", "~> 7.0"
 gem "blacklight_advanced_search", "~> 7.0" #,  :path => "../blacklight_advanced_search"
+gem 'blacklight_unapi', :git => 'https://github.com/cul-it/blacklight-unapi', :branch => 'BL7-upgrade'
 
 #gem "stackview_acorn_tester"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/cul-it/blacklight-unapi
+  revision: 8774c50cdd9ffce42a9b6f4e3a1318791c5aff55
+  branch: BL7-upgrade
+  specs:
+    blacklight_unapi (0.1.0)
+      blacklight
+      rails
+
+GIT
   remote: https://github.com/jhu-library-applications/blacklight_cql.git
   revision: 150804b99543f62496a188ed34d35eeac4a1126c
   branch: bl-upgrade
@@ -619,6 +628,7 @@ DEPENDENCIES
   blacklight_advanced_search (~> 7.0)
   blacklight_cql!
   blacklight_range_limit (~> 7.0)
+  blacklight_unapi!
   bootstrap (~> 4.0)
   borrow_direct (>= 1.2.0.pre1, < 2.0)
   byebug

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -87,6 +87,8 @@ class CatalogController < ApplicationController
 
   include BlacklightAdvancedSearch::Controller
   include Blacklight::Catalog
+  include BlacklightUnapi::ControllerExtension
+
   include BlacklightRangeLimit::ControllerOverride
 
   include Blacklight::Marc::Catalog
@@ -440,6 +442,17 @@ class CatalogController < ApplicationController
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
     config.spell_max = 5
+
+    # Add documents to the list of object formats that are supported for all objects.
+    # This parameter is a hash, identical to the Blacklight::Solr::Document#export_formats 
+    # output; keys are format short-names that can be exported. Hash includes:
+    #    :content-type => mime-content-type
+      
+    config.unapi = {
+      'oai_dc_xml' => { :content_type => 'text/xml' } 
+    }
+    config.index.partials << 'microformat'
+    config.show.partials << 'microformat'
 
 
 

--- a/app/views/catalog/_index_marc.html.erb
+++ b/app/views/catalog/_index_marc.html.erb
@@ -152,12 +152,4 @@
       </ul>
     <% end %>
 
-  <% if document.respond_to?(:export_as_openurl_ctx_kev) %>
-    <%#=
-         // Copied from views/catalog/_show_main_content.html.erb
-         // COinS, for Zotero among others.
-    %>
-    <span class="Z3988" title="<%= document.export_as_openurl_ctx_kev(document_partial_name(document)) %>"></span>
-  <% end %>
-
 </div>

--- a/app/views/catalog/_microformat_default.html.erb
+++ b/app/views/catalog/_microformat_default.html.erb
@@ -1,0 +1,2 @@
+<% inject_auto_discovery_link_tag %>
+<%= content_tag :abbr, '', class: 'unapi-id', title: document.id %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,0 +1,15 @@
+<%= render 'previous_next_doc' if @search_context && search_session['document_id'] == @document.id %>
+
+<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
+<% content_for(:head) { render_link_rel_alternates } %>
+
+<%= render (blacklight_config.show.document_component || Blacklight::DocumentComponent).new(document: @document, component: :div, title_component: :h1, show: true) do |component| %>
+
+  <%# Use :body for complete backwards compatibility (overriding the component body markup),
+        but if the app explicitly  opted-in to components, make the partials data available as :partials to ease migrations pain %>
+  <% component.with(blacklight_config.show.document_component.blank? && blacklight_config.view_config(:show).partials.any? ? :body : :partials) do %>
+    <div id="doc_<%= @document.id.to_s.parameterize %>">
+      <%= render_document_partials @document, blacklight_config.view_config(:show).partials, component: component %>
+    </div>
+  <% end %>
+<% end %>

--- a/test/system/detail_page_test.rb
+++ b/test/system/detail_page_test.rb
@@ -19,7 +19,7 @@ class DetailPageTest < ApplicationSystemTestCase
     assert page.has_selector?("div.umlaut")
     # assert page.has_selector?("ul.holdings")
     assert page.has_selector?("dl.dl-marc-display")
-    # assert page.has_selector?("span.Z3988")
+    assert page.has_selector?('.unapi-id', visible: false)
     assert page.has_selector?("section.page-sidebar")
     assert page.has_selector?("div.show-tools")
     assert page.has_selector?("li.bookmark")

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -9,9 +9,9 @@ class SearchTest < ApplicationSystemTestCase
     assert page.has_content?('Any Field')
   end
 
-  def test_having_coins_element
+  def test_having_unapi_element
     visit '/catalog?utf8=✓&search_field=all_fields&q=*'
 
-    assert page.has_selector?('span.Z3988', visible: false)
+    assert page.has_selector?('.unapi-id', visible: false)
   end
 end


### PR DESCRIPTION
unAPI can now be used by Zotero, the RefWork bookmarklet and other citation mangers to capture item metadata for both individual and bulk export (search results and bookmark pages).

https://github.com/cul-it/blacklight-unapi