### PR TITLE
Upload SimpleCov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,10 @@ jobs:
             RUBYOPT: W0
           run: |
             bundle exec rake ci
+
+        - name: Upload SimpleCov coverage files
+          uses: actions/upload-artifact@v2
+          with: 
+            name: coverage
+            path: coverage
+            


### PR DESCRIPTION
This adds the coverage report from SimpleCov to
the GitHub Actions CI workflow.

The results can be accessed on the page for the CI run in the Artifacts section:
<img width="1446" alt="Screen Shot 2021-07-02 at 3 44 20 PM" src="https://user-images.githubusercontent.com/4324761/124326757-9ba1c600-db4c-11eb-8066-6756104c4335.png">

When you download the artifact it will be a zipped folder with HTML. 