### PR TITLE
LAGSCRUM-196 Unrelated "Online Access" link appearing in map records

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -166,5 +166,10 @@ module ApplicationHelper
   end
 
 
-
+  def should_include_findit_url?(document:)
+    return false if document.nil?
+    return false if document['format'].include?('Map/Globe')
+    
+    true
+  end
 end

--- a/app/views/application/_borrow_direct.html.erb
+++ b/app/views/application/_borrow_direct.html.erb
@@ -23,11 +23,12 @@
 
 <div class="card modal-panel-expand umlaut borrow_direct mb-4 <%= panel_classes %>">
   <%# hidden findit link used by Javascript to load Umlaut borrow_direct info %>
-  <%= link_to("FindIt@JH", JHConfig.params[:umlaut_base_url] +  "/resolve?#{document.export_as_openurl_ctx_kev}" ,
-        :rel=>"nofollow",
-        :class=>"findit_link",
-        :style => "display:none;")  %>
-
+  <% if should_include_findit_url?(document: document) %>
+    <%= link_to("FindIt@JH", JHConfig.params[:umlaut_base_url] +  "/resolve?#{document.export_as_openurl_ctx_kev}" ,
+          :rel=>"nofollow",
+          :class=>"findit_link",
+          :style => "display:none;")  %>
+  <% end %>
   <div class="card-header">
     BorrowDirect <br/>
     <small>Get a copy from a partner library in 2-3 weeks. Checkout period is 16 weeks, with no renewals.</small>

--- a/app/views/catalog/_show_marc.html.erb
+++ b/app/views/catalog/_show_marc.html.erb
@@ -5,6 +5,7 @@
       links_presenter = MarcDisplay::FieldPresenter.new(document, document.to_marc, JHConfig.params[:links_presenter].first)
   -%>
 
+  <% if should_include_findit_url?(document: document) %>
     <div class="links card mb-4">
       <div class="card-header"><h3 class="card-title mb-0 h6" data-umlaut-update="heading"><%= related_links_title(document) %></h3></div>
 
@@ -22,17 +23,18 @@
           %>
           <!-- the Find It link -->
           <% if( JHConfig.params[:umlaut_base_url] &&
-                 document.export_formats.keys.include?(:openurl_ctx_kev)) %>
-                <%= link_to(JHConfig.params[:umlaut_base_url] +  "/resolve?#{document.export_as_openurl_ctx_kev}" , :rel=>"nofollow", :class=>"findit_link") do %>
-                  <%= image_tag("jhu_findit.gif",  :alt=>"Find It @ JH") %>
-                <% end %>
-          <% end %>
+            document.export_formats.keys.include?(:openurl_ctx_kev)) %>
+            
+              <%= link_to(JHConfig.params[:umlaut_base_url] +  "/resolve?#{document.export_as_openurl_ctx_kev}" , :rel=>"nofollow", :class=>"findit_link") do %>
+              <%= image_tag("jhu_findit.gif",  :alt=>"Find It @ JH") %>
+              <% end %>
+            <% end %>
         </div>
 
       </div>
 
     </div>
-
+  <% end %>
     <%# borrow direct section, only where appropriate. This duplicates some of
         what's in FindIt/Umlaut, sorry.  %>
     <% if related_hathi_links_etas_only(document).length == 0 %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -28,4 +28,13 @@ class ApplicationHelperTest < ActionView::TestCase
 
     assert_match /search-option btn active btn-primary/, search_button
   end
+
+
+  test 'should_include_findit_url helper' do
+    should_not_include = should_include_findit_url?(document: { 'format' => ['Map/Globe', 'Print'] })
+    should_include = should_include_findit_url?(document: { 'format' => ['Book', 'Print'] })
+    
+    assert_equal should_not_include, false
+    assert_equal should_include, true
+  end
 end


### PR DESCRIPTION
This adds a helper that checks the format of the Solr document being
displayed. If it has the 'Map/Globe' format it won't display FindIt URLs
or load the FindIt JS on the item page.

FindIt was sending maps to SFX as books. We don't have map coverage in SFX
so this ensures we don't look anyway.