### PR TITLE
LAGSCRUM-196 Unrelated "Online Access" link appearing in map records

### DIFF
--- a/app/javascript/umlaut_include.js
+++ b/app/javascript/umlaut_include.js
@@ -12,7 +12,9 @@
  */
 
 Blacklight.onLoad(function(){
-
+  // Hide the Related Links/Online Access div if there are no MARC 856 entries
+  // This should only be occuring on Map/Globe show pages now
+  if (!$('.marc856').text().trim()) { $('.showmarc.links').hide() }
 
   //Pass in a 'dd' element, will "show" both it and it's
   //corresponding 'dt' element. We use it to show hidden dd/dt combos

--- a/app/views/catalog/_show_marc.html.erb
+++ b/app/views/catalog/_show_marc.html.erb
@@ -5,7 +5,7 @@
       links_presenter = MarcDisplay::FieldPresenter.new(document, document.to_marc, JHConfig.params[:links_presenter].first)
   -%>
 
-  <% if should_include_findit_url?(document: document) %>
+
     <div class="links card mb-4">
       <div class="card-header"><h3 class="card-title mb-0 h6" data-umlaut-update="heading"><%= related_links_title(document) %></h3></div>
 
@@ -21,12 +21,14 @@
           <%=
           render :partial => "marc_display/presenter_content", :locals => {:presenter => links_presenter } if links_presenter.should_display?
           %>
+          <% if should_include_findit_url?(document: document) %>
           <!-- the Find It link -->
-          <% if( JHConfig.params[:umlaut_base_url] &&
-            document.export_formats.keys.include?(:openurl_ctx_kev)) %>
-            
-              <%= link_to(JHConfig.params[:umlaut_base_url] +  "/resolve?#{document.export_as_openurl_ctx_kev}" , :rel=>"nofollow", :class=>"findit_link") do %>
-              <%= image_tag("jhu_findit.gif",  :alt=>"Find It @ JH") %>
+            <% if( JHConfig.params[:umlaut_base_url] &&
+              document.export_formats.keys.include?(:openurl_ctx_kev)) %>
+              
+                <%= link_to(JHConfig.params[:umlaut_base_url] +  "/resolve?#{document.export_as_openurl_ctx_kev}" , :rel=>"nofollow", :class=>"findit_link") do %>
+                <%= image_tag("jhu_findit.gif",  :alt=>"Find It @ JH") %>
+                <% end %>
               <% end %>
             <% end %>
         </div>
@@ -34,7 +36,7 @@
       </div>
 
     </div>
-  <% end %>
+
     <%# borrow direct section, only where appropriate. This duplicates some of
         what's in FindIt/Umlaut, sorry.  %>
     <% if related_hathi_links_etas_only(document).length == 0 %>


### PR DESCRIPTION
This hides blank MARC 856 fields that may show on Map/Globe items because
they are no longer using FindIt. The umlaut js was reformatting the content in this div.

This will no longer be needed if we use SFX directly for online access links.