### PR TITLE
LAGSCRUM-196 Unrelated "Online Access" link appearing in map records …

### DIFF
--- a/app/javascript/umlaut_include.js
+++ b/app/javascript/umlaut_include.js
@@ -14,7 +14,7 @@
 Blacklight.onLoad(function(){
   // Hide the Related Links/Online Access div if there are no MARC 856 entries
   // This should only be occuring on Map/Globe show pages now
-  if (!$('.marc856').text().trim()) { $('.showmarc.links').hide() }
+  if (!$('.marc856').text().trim()) { $('.links').hide() }
 
   //Pass in a 'dd' element, will "show" both it and it's
   //corresponding 'dt' element. We use it to show hidden dd/dt combos


### PR DESCRIPTION
…(#169)

This hides blank MARC 856 fields that may show on Map/Globe items becase
they are no longer using FindIt. The umlaut js was reformatting the content in this div.

This will no longer be needed if we use SFX directly for online access links.