### PR TITLE
LAGSCRUM-350 Write rake task to remove guest users

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,4 +12,8 @@ every :day, at: '2:00am' do
    rake 'nightly_cleanup'
 end
 
+every :hour do
+   rake 'purge_guest_users'
+end
+
 # Learn more: http://github.com/javan/whenever

--- a/lib/tasks/nightly_cleanup.rake
+++ b/lib/tasks/nightly_cleanup.rake
@@ -21,3 +21,17 @@ task 'purge_searches' => :environment do
     puts 'An error occurred when truncating the searches table.'
   end
 end
+
+desc 'purge old guest user data'
+task 'purge_guest_users' => :environment do
+  # This removes guest users which accumulate in the 
+  # the users table. 
+  begin
+    ActiveRecord::Base.connection.execute("DELETE FROM users WHERE users.login LIKE '%guest_user%' AND updated_at < NOW() - INTERVAL 1 DAY LIMIT 10000")
+    puts 'The users table has been reduced in size.'
+  rescue ActiveRecord::ConnectionNotEstablished
+    puts 'There was a problem connecting to the database.'
+  rescue StandardError
+    puts 'An error occurred when cleaning the users table.'
+  end
+end


### PR DESCRIPTION
This will remove (10,000) guest users on an hourly basis. We
have a large number of these in the db so they need
to be removed slowly on the production db.