### PR TITLE
LAG-4727 Test back button behavior on Catalyst detail record

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,7 +32,7 @@ set :passenger_roles, :web
 append :linked_files, "config/database.yml", "config/blacklight.yml", ".env"
 
 # Default value for linked_dirs is []
-append :linked_dirs, "log", "tmp/pids", "tmp/sockets", "public/system", ".bundle"
+append :linked_dirs, "log", "tmp/cache", "tmp/pids", "tmp/sockets", "public/system", ".bundle"
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
This adds the `tmp/cache` folder to capistrano's shared folders
this will avoid creating a new cache when deploying.