### PR TITLE
LAG-4727 Test back button behavior on Catalyst detail record

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,12 @@
+require 'uri'
 #require_dependency 'vendor/plugins/blacklight/app/helpers/application_helper.rb'
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
 
-
-
-
+  def url_decode(url)
+    URI.decode(url)
+  end
+ 
   # Over-ride Umlaut default
   def application_name
     "JH Libraries"

--- a/app/views/online_access/show.html.erb
+++ b/app/views/online_access/show.html.erb
@@ -1,5 +1,5 @@
 <% @urls[:show_targets].each do |url| %>
-  <%= "<p><a href='#{url.css('target_url').text}'>#{url.css('target_public_name').text}</a></br>".html_safe %>
+  <%= "<p><a href='#{url_decode(url.css('target_url').text)}'>#{url.css('target_public_name').text}</a></br>".html_safe %>
   <% url.css('coverage_statement').each do |coverage_statement| %>
     <%= coverage_statement.text %>
     </br>
@@ -10,7 +10,7 @@
   <a class="view-overflow-urls btn-sm btn-primary btn"><span class="overflow-label">View</span> <%= @urls[:overflow_targets].size %> More</a>
   <div class="overflow-urls">
     <% @urls[:overflow_targets].each do |url| %>
-     <%= "<p><a href='#{url.css('target_url').text}'>#{url.css('target_public_name').text}</a></br>".html_safe %>
+     <%= "<p><a href='#{url_decode(url.css('target_url').text)}'>#{url.css('target_public_name').text}</a></br>".html_safe %>
   <% url.css('coverage_statement').each do |coverage_statement| %>
     <%= coverage_statement.text %>
     </br>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
 
+  test 'that we can easily decode a URL' do
+    assert_equal('http://proxy.library.jhu.edu/login?url=http://www.heinonline.org/HOL/Index?collection=journals&index=journals/afjincol', url_decode('http://proxy.library.jhu.edu/login?url=http://www.heinonline.org/HOL/Index?collection=journals&index=journals%2Fafjincol'))
+  end
+ 
   def current_page?(arg)
     true
   end


### PR DESCRIPTION
This adds a helper method used for URI decoding the links
from SFX. HeinOnline links were not working correctly without
this change.