### PR TITLE
Add a polyfill for IntersectionObserver, which isn't present in IE11

### DIFF
--- a/app/javascript/load_online_access.js
+++ b/app/javascript/load_online_access.js
@@ -1,3 +1,4 @@
+import IntersectionObserver from 'intersection-observer-polyfill'
 import { onlineAccessOverflow } from './online_access_overflow'
 import isbot from 'isbot'
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "chosen-js": "^1.8.7",
     "core-js": "^3.8.3",
     "dom4": "^2.1.6",
+    "intersection-observer-polyfill": "^0.1.0",
     "is-svg": "4.2.2",
     "isbot": "^3.3.1",
     "jquery": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3597,6 +3597,11 @@ interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+intersection-observer-polyfill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer-polyfill/-/intersection-observer-polyfill-0.1.0.tgz#f9ef8e5a6f3e0e8173d0c0fdb563e47a9dda233c"
+  integrity sha1-+e+OWm8+DoFz0MD9tWPkep3aIzw=
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"


### PR DESCRIPTION
This addition fixes this IE11 bug: https://sentry.io/organizations/johns-hopkins-library-applicat/issues/2918084170/?project=5634978