### PR TITLE
LAGSCRUM-548 Implement workflow to overlay subject headings in Catalyst

### DIFF
--- a/.docker/catalyst/Dockerfile
+++ b/.docker/catalyst/Dockerfile
@@ -12,7 +12,9 @@ RUN apk update && apk add --no-cache \
   tzdata \
   shared-mime-info \
   yarn \
-  curl
+  curl \
+  openssh \
+  openssh-client-common
 
 # Installs latest Chromium package.
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories \

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -306,8 +306,8 @@ class CatalogController < ApplicationController
     config.add_search_field("subject") do |field|
       field.label = 'Subject'
       field.solr_local_parameters = {
-        :qf => "$subject_translated_qf AND $subject_qf",
-        :pf => "$subject_translated_pf AND $subject_pf"
+        :qf => "subject_translated_unstem AND subject_unstem",
+        :pf => "subject_translated_unstem AND subject_unstem"
       }
       field.solr_parameters = {
         :"spellcheck.dictionary" => "subject"

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -306,8 +306,8 @@ class CatalogController < ApplicationController
     config.add_search_field("subject") do |field|
       field.label = 'Subject'
       field.solr_local_parameters = {
-        :qf => "$subject_qf",
-        :pf => "$subject_pf"
+        :qf => "$subject_translated_qf $subject_qf",
+        :pf => "$subject_translated_pf $subject_pf"
       }
       field.solr_parameters = {
         :"spellcheck.dictionary" => "subject"
@@ -458,7 +458,7 @@ class CatalogController < ApplicationController
         "title3_unstem^30",
         "title_series_unstem^25"
       ],
-
+      :subject_translated_qf => "subject_translated_unstem^40",
       :subject_qf  => "subject_unstem^40",
       :series_qf   => "title_series_unstem^10",
       # this 'qf' will be used for default 'all fields' search

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -306,8 +306,8 @@ class CatalogController < ApplicationController
     config.add_search_field("subject") do |field|
       field.label = 'Subject'
       field.solr_local_parameters = {
-        :qf => "$subject_translated_qf $subject_qf",
-        :pf => "$subject_translated_pf $subject_pf"
+        :qf => "$subject_translated_qf AND $subject_qf",
+        :pf => "$subject_translated_pf AND $subject_pf"
       }
       field.solr_parameters = {
         :"spellcheck.dictionary" => "subject"
@@ -316,7 +316,7 @@ class CatalogController < ApplicationController
 
     # Combining numbers is weird. Call numbers end up as multiple tokens,
     # so we use pf/ps/mm to try to make sure call number searches are reasonable
-    # Everything else should just be one token, usually.
+    # Everything else should subjectust be one token, usually.
     config.add_search_field("number") do |field|
       field.label = "Numbers"
       field.solr_local_parameters = {
@@ -332,7 +332,7 @@ class CatalogController < ApplicationController
 
     # Journal title is a copy of title -- we have custom logic below
     # that hardcodes in the facet limit.
-    config.add_search_field("journal_title") do |field|
+    config.add_search_field("subjectournal_title") do |field|
       field.label = 'Journal Title'
       field.solr_local_parameters = {
         :qf => "$title_qf",
@@ -471,6 +471,7 @@ class CatalogController < ApplicationController
         'author_unstem^90',
         'author_addl_unstem^40',
         'subject_unstem^20',
+        'subject_translated_unstem^20',
         'title_series_unstem^10',
         'isbn_t',
         'issn',

--- a/app/lib/subject_overrider.rb
+++ b/app/lib/subject_overrider.rb
@@ -1,0 +1,19 @@
+require 'yaml'
+
+class SubjectOverrider
+  attr_accessor :line, :part
+  attr_reader :overrides
+
+  def initialize(line:, part:)
+    @line = line
+    @part = part
+
+    @overrides = YAML.load(File.open(Rails.root.join('config', 'translation_maps', 'subject_overrides.yml').to_s))
+  end
+
+  def translated_subject
+    @overrides[part.formatted_value.to_s] || part.formatted_value.to_s
+  end
+end
+
+

--- a/app/lib/subject_overrider_terms.rb
+++ b/app/lib/subject_overrider_terms.rb
@@ -1,0 +1,20 @@
+require 'yaml'
+
+class SubjectOverriderTerms
+  attr_accessor :terms
+  attr_reader :overrides
+
+  def initialize(terms:)
+    @terms = terms
+
+    @overrides = YAML.load(File.open(Rails.root.join('config', 'translation_maps', 'subject_overrides.yml').to_s))
+  end
+
+  def translated_terms
+    terms.map { |term| @overrides[term_as_key(term)] || term  }
+  end
+
+  def term_as_key(term)
+    term.strip.tr('\"', '')
+  end
+end

--- a/config/translation_maps/subject_overrides.yml
+++ b/config/translation_maps/subject_overrides.yml
@@ -1,0 +1,3 @@
+---
+# This is just an example that doesn't conflict with an existing subject. 
+Zzzzzzxyyyyyyy: 'Z'

--- a/marc_display/app/helpers/marc_display_logic.rb
+++ b/marc_display/app/helpers/marc_display_logic.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 
 require 'singleton'
 require 'jh_config'
@@ -283,7 +283,7 @@ module MarcDisplayLogic
     # can cross MARC sub-fields. Specify search field in the display config
     # as normal, this just changes the query to be phrase searches.
     def link_lcsh_subd(link, hash, options ={})
-
+      
       # seperate into an array of strings, one string per subdivision, knowing
       # that subdivisions break on certain subfield codes.
       subdivisions =
@@ -304,7 +304,10 @@ module MarcDisplayLogic
       end
 
       # and join our seperate terms into one query
-      hash[:q] = terms.join(" ")
+      subject_overrides_terms = SubjectOverriderTerms.new(terms: terms).translated_terms
+      
+      hash[:q] = subject_overrides_terms.join(" ")
+
 
       return hash
     end

--- a/marc_display/app/models/marc_display/link.rb
+++ b/marc_display/app/models/marc_display/link.rb
@@ -7,10 +7,10 @@ module MarcDisplay
       attr_accessor :line
       
       @@default_link_text = "More"  
-    
+
+
       def initialize(line, config_hash)
         @line = line
-    
         config_hash = {} if config_hash == true
         if config_hash[:subfields].kind_of?(String)
           config_hash[:subfields] = config_hash[:subfields].split('') 
@@ -26,7 +26,7 @@ module MarcDisplay
         @config_hash = config_hash
       end
     
-      def hash_for_url    
+      def hash_for_url
         hash = {:controller => "catalog",
         :action => "index"}
         if ( facet = @config_hash[:facet])
@@ -74,20 +74,22 @@ module MarcDisplay
       end
     
       def query
-        unless (@query)      
+       unless (@query)
+          
           # Default to just the same as the will be output,
           # but without any prefixes/suffixes
-          @query = @line.parts.collect do |part|
-          
-            if ( @config_hash[:subfields].nil? ||
-                 ((!part.marc_subfield.nil?) &&
-                  @config_hash[:subfields].include?(part.marc_subfield.code)))
-          
-                part.formatted_value
-            end
-          end.compact.join(" ")
-
-          # Remove internal quote marks, they tend to result in not what
+         @query = @line.parts.collect do |part|
+           subject_overrider = SubjectOverrider.new(line: @line, part: part)
+           
+           if ( @config_hash[:subfields].nil? ||
+                ((!part.marc_subfield.nil?) &&
+                 @config_hash[:subfields].include?(part.marc_subfield.code)))
+             
+             subject_overrider.translated_subject
+           end
+         end.compact.join(" ")
+         
+         # Remove internal quote marks, they tend to result in not what
           # was intended, phrase search or not. 
           @query = clean_query(query)
 

--- a/marc_display/app/views/marc_display/_marc_line.html.erb
+++ b/marc_display/app/views/marc_display/_marc_line.html.erb
@@ -1,5 +1,7 @@
 <%# getting the whitespace right in this partial is kind of ridiculous, sorry a better technique is needed. -%>
-  <%- if ( prefix = line.prefix ) -%>
+
+
+<%- if ( prefix = line.prefix ) -%>
     <span class="marcPrefix"><%= prefix %>:</span>
   <%- end -%>
   <%- if (alink = line.link) && alink.as_whole_line? && alink.hash_for_url -%>
@@ -12,7 +14,8 @@
             <%= (prefix || raw_prefix) %><%- unless raw_prefix -%>:<%- end -%>
         </span>
       <%- end -%>
-      <%= part.formatted_value.to_s.html_safe %>
+      <% subject_overrider = SubjectOverrider.new(line: line, part: part) %>
+      <%= subject_overrider.translated_subject.html_safe || part.formatted_value.to_s.html_safe %>
     </span>
   <%- end -%>            
   <%- if (alink = line.link ) -%>

--- a/test/lib/subject_overrider_terms_test.rb
+++ b/test/lib/subject_overrider_terms_test.rb
@@ -1,0 +1,21 @@
+# This tests the SubjectOverriderTerm's ability
+# to override strings when given a YML config file
+
+require 'test_helper'
+require 'ostruct'
+
+class SubjectOverriderTermsTest < ActiveSupport::TestCase
+
+  def setup
+    terms = ['Zzzzzzxyyyyyyy']
+    @subject_overrider_terms = SubjectOverriderTerms.new(terms: terms)
+  end
+
+  test 'that we can get a translated term' do
+    assert_equal @subject_overrider_terms.translated_terms, ['Z']
+  end
+
+  test 'that we can get a clean string to use a key for the map' do
+    assert_equal @subject_overrider_terms.term_as_key('"term"'), 'term'
+  end
+end

--- a/test/lib/subject_overrider_test.rb
+++ b/test/lib/subject_overrider_test.rb
@@ -1,0 +1,23 @@
+# This tests the SubjectOverrider's ability
+# to override strings when given a YML config file
+# that has a translation map
+# like this:
+
+
+# ---
+# Override term: 'translated term'
+require 'test_helper'
+require 'ostruct'
+
+class SubjectOverriderTest < ActiveSupport::TestCase
+
+  def setup
+    line = OpenStruct.new
+    part = OpenStruct.new(formatted_value: 'Zzzzzzxyyyyyyy')
+    @subject_overrider = SubjectOverrider.new(line: line, part: part)
+  end
+
+  test 'that we can get a translated term' do
+    assert_equal @subject_overrider.translated_subject, 'Z'
+  end
+end


### PR DESCRIPTION
This adds a class called `SubjectOverrider` that's used
for overriding subjects based on the translation
map present in `config/translation_maps/subject_overrides.yml`.

A yaml file that has the same name should also be edited in the `catalyst_traject`
repo when making changes to the map.

Catalyst doesn't display values directly from Solr. It displays
content from a binary MARC record stored in Solr. This class
is used to translate the subjects that are displayed from that
record.