### PR TITLE
LAGSCRUM-620 Override Horizon non-circ message

### DIFF
--- a/app/presenters/request_failure_presenter.rb
+++ b/app/presenters/request_failure_presenter.rb
@@ -1,0 +1,18 @@
+class RequestFailurePresenter
+    NON_CIRC_MESSAGE = "You can't request this online; please ask library staff about a copy through other local libraries."
+    NEW_NON_CIRC_MESSAGE = 'You can’t request this item. Please ask library staff about using it in the library or for help locating another copy.'.freeze
+
+    def initialize(exception:)
+        @exception = exception
+    end
+
+    def message
+        return '' unless @exception.present?
+
+        if @exception.message.include?(NON_CIRC_MESSAGE)
+            NEW_NON_CIRC_MESSAGE
+        else
+            @exception.message
+        end
+    end
+end

--- a/app/views/requests/request_failure.html.erb
+++ b/app/views/requests/request_failure.html.erb
@@ -98,7 +98,7 @@
             <span class="text-muted">Get a copy from a BorrowDirect partner library in 6-9 days. Checkout period is 16 weeks, with no renewals.</span>
           </p>
         <% else %>
-          <p><strong><%= @exception.message %></strong></p>
+          <p><strong><%= RequestFailurePresenter.new(exception: @exception).message %></strong></p>
         <% end %>
 
         <% if show_borrow_direct?(@document) && 'You have already requested this item.' != @exception.message %>

--- a/test/presenters/request_failure_presenter_test.rb
+++ b/test/presenters/request_failure_presenter_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+# Test the presenter directly
+class RequestFailurePresenterTest < ActiveSupport::TestCase
+  def setup
+    @message = "You can't request this online; please ask library staff about a copy through other local libraries."
+    @new_message = "You can’t request this item. Please ask library staff about using it in the library or for help locating another copy."
+    @exception = OpenStruct.new({ message: @message })
+    @presenter = RequestFailurePresenter.new(exception: @exception)
+  end
+
+  test 'supports external_links' do
+    assert_equal @presenter.message, @new_message
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'simplecov'
 require 'simplecov-cobertura'
 require 'webmock/minitest'
+require 'ostruct'
 
 SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 


### PR DESCRIPTION
When a user requests an item that is non-circulating
they receive a confusing message. We aren't able to
configure this message in horizon so this is a
simple override.