### PR TITLE
LAGSCRUM-533 Make Catalyst online links from SFX match SFX display

### DIFF
--- a/app/presenters/sfx_service_presenter.rb
+++ b/app/presenters/sfx_service_presenter.rb
@@ -1,0 +1,19 @@
+class SfxServicePresenter
+  SERVICE_MAP = {
+    'getFullTxt' => 'Full text available from ',
+    'getTOC' => 'Table of contents available from ',
+    'getAbstract' => 'Abstract available from '
+  }.freeze
+
+  attr_reader :service_type
+
+  def initialize(service_type:)
+    @service_type = service_type
+  end
+
+  def service
+    return unless service_type.present?
+
+    SERVICE_MAP[service_type]
+  end
+end

--- a/app/views/online_access/_url.html.erb
+++ b/app/views/online_access/_url.html.erb
@@ -1,0 +1,12 @@
+<p>
+    <%= SfxServicePresenter.new(service_type: url.css('service_type').text).service %>
+    <%= "<a href='#{url_decode(url.css('target_url').text)}'>#{url.css('target_public_name').text}</a></br>".html_safe %>
+    <% url.css('coverage_statement').each do |coverage_statement| %>
+        <%= coverage_statement.text %>
+    </br>
+    <% end %>
+    <% url.css('embargo_statement').each do |embargo_statement| %>
+        <%= embargo_statement.text %>
+    </br>
+    <% end %>
+  </p>

--- a/app/views/online_access/show.html.erb
+++ b/app/views/online_access/show.html.erb
@@ -1,28 +1,10 @@
 <% @urls[:show_targets].each do |url| %>
-    <%= "<p><a href='#{url_decode(url.css('target_url').text)}'>#{url.css('target_public_name').text}</a></br>".html_safe %>
-    <% url.css('coverage_statement').each do |coverage_statement| %>
-        <%= coverage_statement.text %>
-    </br>
-    <% end %>
-    <% url.css('embargo_statement').each do |embargo_statement| %>
-        <%= embargo_statement.text %>
-    </br>
-    <% end %>
-  </p>
+    <%= render 'url', url: url %>
 <% end %>
 <% unless @urls[:overflow_targets].nil? %>
   <a class="view-overflow-urls btn-sm btn-primary btn"><span class="overflow-label">View</span> <%= @urls[:overflow_targets].size %> More</a>
   <div class="overflow-urls">
       <% @urls[:overflow_targets].each do |url| %>
-          <%= "<p><a href='#{url_decode(url.css('target_url').text)}'>#{url.css('target_public_name').text}</a></br>".html_safe %>
-          <% url.css('coverage_statement').each do |coverage_statement| %>
-              <%= coverage_statement.text %>
-    </br>
-          <% end %>
-          <% url.css('embargo_statement').each do |embargo_statement| %>
-              <%= embargo_statement.text %>
-    </br>
-  <% end %>
-    </p>
-  <% end %>
+         <%= render 'url', url: url %>
+      <% end %>
 <% end %>

--- a/test/presenters/sfx_service_presenter_test.rb
+++ b/test/presenters/sfx_service_presenter_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'ostruct'
+
+class SfxServicePresenterTest < ActiveSupport::TestCase
+    def setup
+        @service_type = 'getFullTxt'
+        @service_type_abstract = 'getAbstract'
+        @service_type_toc = 'getTOC'
+    end
+
+    test 'that we can translate SFX service codes to human-readable text' do
+        assert_equal SfxServicePresenter.new(service_type: @service_type).service, 'Full text available from '
+        assert_equal SfxServicePresenter.new(service_type: @service_type_abstract).service, 'Abstract available from '
+        assert_equal SfxServicePresenter.new(service_type: @service_type_toc).service, 'Table of contents available from '
+    end
+end


### PR DESCRIPTION
This adds the SFX service type to the display of Online Access
links.