### PR TITLE
Add Horizon holding info servlet to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     depends_on:
       - solr
       - db
+      - horizon_holding_info
     tty: true
     stdin_open: true
     ports:
@@ -28,7 +29,7 @@ services:
       - FLIPPER_PASSWORD=flipper
       - BORROW_DIRECT_HOST=bdtest.relaisd2d.com
       - CATALYST_UMLAUT_BASE_URL=https://findit.library.jhu.edu
-      - HORIZON_WS_URL=http://localhost:8080/ws
+      - HORIZON_WS_URL=http://horizon_holding_info:8080/ws
       - GOOGLE_BOOKS_API_KEY="${GOOGLE_BOOKS_API_KEY}"
       - SECRET_KEY_BASE="${SECRET_KEY_BASE}"
       - SFX_BASE_URL="sfx.library.jhu.edu"
@@ -50,7 +51,10 @@ services:
       - "8983:8983"
     volumes:
       - solr:/var/solr/data
-
+  horizon_holding_info:
+    image: "ghcr.io/jhu-library-applications/horizon-holding-info-servlet"
+    ports:
+      - "8080:8080" 
   db:
     image: mysql
     environment:


### PR DESCRIPTION
This adds the horizon-holding-info-servlet to do the `docker-compose`
file. It's preconfigured to work with horizon stage.